### PR TITLE
Allow users to select join mode (default is "space")

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 	flags.UintVarP(&opts.Passphrases, "passphrases", "n", 1, "generate `n` passphrases")
 	flags.StringVarP(&opts.Wordlist, "wordlist", "l", "en", fmt.Sprintf("use `wordlist` as the source for words (valid: %v)", strings.Join(wordlists.Names(), ", ")))
 	flags.BoolVarP(&opts.Reconstruct, "reconstruct", "r", false, "interactively reconstruct a password based on a wordlist")
-	flags.StringVarP(&opts.JoinMode, "join-mode", "j", JoinModeSpace, "choose how words are joined: 'space' (like this, default), 'camel' (LikeThis) or minus (like-this)")
+	flags.StringVarP(&opts.JoinMode, "join-mode", "j", JoinModeSpace, "choose how words are joined (\"space\" (like this), \"camel\" (LikeThis) or \"minus\" (like-this))")
 
 	err := flags.Parse(os.Args)
 	if err == pflag.ErrHelp {

--- a/main.go
+++ b/main.go
@@ -78,7 +78,8 @@ func generate(n uint, list []string, joinMode string) string {
 		capitalize(words)
 		return strings.Join(words, "")
 	default:
-		die("unknown join mode: %s", joinMode)
+		die("unknown join mode %q: choose between %q, %q and %q", joinMode,
+			JoinModeSpace, JoinModeCamel, JoinModeMinus)
 		return ""
 	}
 }


### PR DESCRIPTION
This PR allows users to choose the word join mode between "space" (like this), "camel" (LikeThis) and "minus" (like-this). Previously, the default was "camel", with this PR the default is "space".